### PR TITLE
fix broken line matching

### DIFF
--- a/xontrib/pacman_tabcomplete.xsh
+++ b/xontrib/pacman_tabcomplete.xsh
@@ -27,11 +27,11 @@ def pacman_completer(prefix, line, begidx, endidx, ctx):
     """
     Completes pacman remove command with installed package names
     """
-    if 'pacman' and '-R' in line:
+    if 'pacman' in line and '-R' in line:
         return search_pacman(prefix)
-    elif 'pacman' and '-Ss' in line:
+    elif 'pacman' in line and '-Ss' in line:
         return search_pacman(prefix, installed=False, remote=True)
-    elif 'pacman' and '-Qs' in line:
+    elif 'pacman' in line and '-Qs' in line:
         return search_pacman(prefix, installed=False, remote=False)
 
 #add to list of completers


### PR DESCRIPTION
The current matching matches for `-Q` when it looks like it's intended to only match `pacman -Q` and so on. :) 
